### PR TITLE
change NewClient to accept an `*http.Client` instead of `token, httpRoundTripper`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,13 +17,30 @@
   version = "v1.7.0"
 
 [[projects]]
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
     "idna",
     "publicsuffix"
   ]
   revision = "292b43bbf7cb8d35ddf40f8d5100ef3837cced3f"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "ef147856a6ddbb60760db74283d2424e98c87bff"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -47,6 +64,20 @@
   version = "v0.3.0"
 
 [[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
+
+[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
@@ -55,6 +86,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22d93eb120e3a6d6d5822881cad8cc10ed9d6b69e03297d1f52077f94bf181b4"
+  inputs-digest = "7488619b2bac0b91fd97a9227641d3fbb1c9ae2bfa3c84663d9fb3e22904f0bd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ A brief summary of the features offered in this API client are shown here.
 package main
 
 import (
+  "context"
   "fmt"
   "log"
   "os"
 
   "github.com/chiefy/linodego"
+  "golang.org/x/oauth2"
 )
 
 func main() {
@@ -63,7 +65,7 @@ func main() {
     log.Fatal(err)
   }
   linodeClient.SetDebug(true)
-  res, err := linodeClient.GetInstance(4090913)
+  res, err := linodeClient.GetInstance(context.Background(), 4090913)
   if err != nil {
     log.Fatal(err)
   }
@@ -85,7 +87,7 @@ kernels, err := linodego.ListKernels(nil)
 ```go
 opts := NewListOptions(2,"")
 // or opts := ListOptions{PageOptions: &PageOptions: {Page: 2 }}
-kernels, err := linodego.ListKernels(opts)
+kernels, err := linodego.ListKernels(context.Background(), opts)
 // len(kernels) == 100
 // opts.Results == 218
 ```
@@ -95,7 +97,7 @@ kernels, err := linodego.ListKernels(opts)
 ```go
 opts := ListOptions{Filter: "{\"mine\":true}"}
 // or opts := NewListOptions(0, "{\"mine\":true}")
-stackscripts, err := linodego.ListStackscripts(opts)
+stackscripts, err := linodego.ListStackscripts(context.Background(), opts)
 ```
 
 ### Error Handling
@@ -103,7 +105,7 @@ stackscripts, err := linodego.ListStackscripts(opts)
 #### Getting Single Entities
 
 ```go
-linode, err := linodego.GetLinode(555) // any Linode ID that does not exist or is not yours
+linode, err := linodego.GetLinode(context.Background(), 555) // any Linode ID that does not exist or is not yours
 // linode == nil: true
 // err.Error() == "[404] Not Found"
 // err.Code == "404"
@@ -115,7 +117,7 @@ linode, err := linodego.GetLinode(555) // any Linode ID that does not exist or i
 For lists, the list is still returned as `[]`, but `err` works the same way as on the `Get` request.
 
 ```go
-linodes, err := linodego.ListLinodes(NewListOptions(0, "{\"foo\":bar}"))
+linodes, err := linodego.ListLinodes(context.Background(), NewListOptions(0, "{\"foo\":bar}"))
 // linodes == []
 // err.Error() == "[400] [X-Filter] Cannot filter on foo"
 ```
@@ -123,7 +125,7 @@ linodes, err := linodego.ListLinodes(NewListOptions(0, "{\"foo\":bar}"))
 Otherwise sane requests beyond the last page do not trigger an error, just an empty result:
 
 ```go
-linodes, err := linodego.ListLinodes(NewListOptions(9999, ""))
+linodes, err := linodego.ListLinodes(context.Background(), NewListOptions(9999, ""))
 // linodes == []
 // err = nil
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ func main() {
   if !ok {
     log.Fatal("Could not find LINODE_TOKEN, please assert it is set.")
   }
-  linodeClient, err := linodego.NewClient(apiKey)
+  tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})
+
+  oauth2Client := &http.Client{
+    Transport: &oauth2.Transport{
+      Source: tokenSource,
+    },
+  }
+
+  linodeClient, err := linodego.NewClient(oauth2Client)
   if err != nil {
     log.Fatal(err)
   }
@@ -60,7 +68,6 @@ func main() {
     log.Fatal(err)
   }
   fmt.Printf("%v", res)
-
 }
 ```
 

--- a/resources_test.go
+++ b/resources_test.go
@@ -1,13 +1,19 @@
 package linodego
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestResourceEndpoint(t *testing.T) {
 	apiKey := "MYFAKEAPIKEY"
-	client := NewClient(&apiKey, nil)
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})
+	oc := oauth2.NewClient(context.Background(), tokenSource)
+	client := NewClient(oc)
 
 	r := client.Resource("images")
 	e, err := r.Endpoint()
@@ -21,7 +27,11 @@ func TestResourceEndpoint(t *testing.T) {
 }
 func TestResourceTemplatedendpointWithID(t *testing.T) {
 	apiKey := "MYFAKEAPIKEY"
-	client := NewClient(&apiKey, nil)
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})
+	oc := oauth2.NewClient(context.Background(), tokenSource)
+	client := NewClient(oc)
+
 	backupID := 1234255
 	e, err := client.InstanceSnapshots.endpointWithID(backupID)
 	if err != nil {


### PR DESCRIPTION
By accepting a http.Client we leave more of the `http` client configuration and configuration up to the API consumer.  For example, the oauth2.NewClient can now be passed in to provide Oauth2 client workflows (with client_id, client_secret, and refresh tokens).

In the examples and tests I am only making use of personal access tokens.

---

Relates to https://github.com/chiefy/linodego/pull/23